### PR TITLE
Adding the option to rename the controller.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* Option to rename the anonymous controller
+
 ## [0.0.4] - 2021-09-13
 
 ### Fixed

--- a/lib/rails_anonymous_controller_testing/railtie.rb
+++ b/lib/rails_anonymous_controller_testing/railtie.rb
@@ -15,6 +15,10 @@ class RailsAnonymousControllerTesting::Railtie < ::Rails::Railtie
         @_anonymous_controller_name ||= "AnonymousController"
       end
 
+      def self._anonymous_controller_name=(value)
+        @_anonymous_controller_name = value
+      end
+
       def self._anonymous_view_cache?
         if instance_variable_defined?(:@_anonymous_view_cache)
           @_anonymous_view_cache
@@ -39,7 +43,7 @@ class RailsAnonymousControllerTesting::Railtie < ::Rails::Railtie
         @_anonymous_views = value
       end
 
-      def self.controller(base_controller, routes: nil, &block)
+      def self.controller(base_controller, routes: nil, controller_name: "AnonymousController", &block)
         caller_location = caller_locations(1, 10).find { |location| location.absolute_path != __FILE__ }
 
         display_name =
@@ -60,6 +64,7 @@ class RailsAnonymousControllerTesting::Railtie < ::Rails::Railtie
           end
 
         anonymous_view_path = _anonymous_view_base_path.join("#{display_name}_#{unique_identifier}")
+        self._anonymous_controller_name = controller_name
         anonymous_controller_name = _anonymous_controller_name
 
         # Define the controller

--- a/test/custom_controller_name_test.rb
+++ b/test/custom_controller_name_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class CustomControllerNameTest < ActionDispatch::IntegrationTest
+  controller(ApplicationController, controller_name: "CustomsController") do
+    def index
+      render plain: self.class.name
+    end
+  end
+
+  test "route matches controller name" do
+    get "/customs"
+    assert_equal(200, response.status)
+  end
+
+  test "controller name is correct" do
+    get "/customs"
+    assert_equal("CustomsController", response.body)
+  end
+end


### PR DESCRIPTION
This makes it possible that one changes the name of the controller. In my case I required this, because I had some validations in a controller concern that changed depending on the controller name.

Now I can do something like this:

```ruby
    controller(ApplicationController, controller_name: 'CardsController') do
      def index
        render plain: 'You can see this page'
      end
    end

   test "bookkeeping can see index page" do
      get "/cards"
      assert_equal "You can see this page", response.body
    end
    test "bookkeeping can see show page" do
      get "/cards/1"
      assert_equal "You can see this page", response.body
    end
    test "bookkeeping can not see edit page" do
      get "/cards/1/edit"
      assert_match "403", response.body
    end
```